### PR TITLE
Support new manifest.json properties 'cssThemes' and 'cssThemesExtension'

### DIFF
--- a/src/schemas/layout.schema.json
+++ b/src/schemas/layout.schema.json
@@ -61,13 +61,13 @@
                 "type": "object"
             }
         },
-        "CSS-Themes": {
+        "cssThemes": {
             "type": "array",
             "items": {
                 "type": "object"
             }
         },
-        "CSS-Themes-Extension": {
+        "cssThemesExtension": {
             "type": "array",
             "items": {
                 "type": "object"

--- a/src/schemas/manifest.schema.json
+++ b/src/schemas/manifest.schema.json
@@ -430,11 +430,21 @@
         "layout-templates": {
             "$ref": "layout.schema.json#/definitions/layout-templates"
         },
+
+        "cssThemes": {
+            "$ref": "layout.schema.json#/definitions/cssThemes"
+        },
+        "cssThemesExtension": {
+            "$ref": "layout.schema.json#/definitions/cssThemesExtension"
+        },
+
         "CSS-Themes": {
-            "$ref": "layout.schema.json#/definitions/CSS-Themes"
+            "deprecationMessage": "Use \"cssThemes\" instead. Since version 4.13.2.",
+            "$ref": "layout.schema.json#/definitions/cssThemes"
         },
         "CSS-Themes-Extension": {
-            "$ref": "layout.schema.json#/definitions/CSS-Themes-Extension"
+            "deprecationMessage": "Use \"cssThemesExtension\" instead. Since version 4.13.2.",
+            "$ref": "layout.schema.json#/definitions/cssThemesExtension"
         },
         
         


### PR DESCRIPTION
Support new manifest.json properties 'cssThemes' and 'cssThemesExtension' during schema validation.

In the next version of map.apps the keys "CSS-Themes" and "CSS-Themes-Extension" are renamed.
The new keys are 'cssThemes' and 'cssThemesExtension', it would be perfect if this change is validated and a deprecation warning is shown if your plugin is used.